### PR TITLE
Add dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'eventmachine'
-gem 'em-synchrony'
-gem 'em-http-request'
-gem 'activesupport'
-gem 'fastimage'
-gem 'oj'
-
-group :test, :development do
-  # irb
-  gem 'rubysl-irb'
-  # rubydoc
-  gem 'yard'
-  # ruby profiler
-  gem 'ruby-prof'
-end
-
+gemspec 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A Ruby wrapper that communicates with the [Telegram-CLI](https://github.com/vysh
 ### Requirements
 
 * You need to install the [Telegram-CLI](https://github.com/vysheng/tg) first.
-* [EventMachine](https://github.com/eventmachine/eventmachine) is required for telegram-rb.
 
 ### RubyGems
 
@@ -28,29 +27,25 @@ or in your `Gemfile`:
 
 ```ruby
 # latest stable
-gem 'telegram-rb'
+gem 'telegram-rb', require: 'telegram'
 
 # or track master repo
-gem 'telegram-rb', :github => 'ssut/telegram-rb'
-```
-
-or install it from a source code checkout:
-
-```bash
-$ git clone https://github.com/ssut/telegram-rb.git
-$ cd telegram-rb
-$ bundle install
+gem 'telegram-rb', github: 'ssut/telegram-rb', require: 'telegram'
 ```
 
 ## Usage
 
-You must use eventmachine library for use, so telegram-rb uses callback at all.
+The library uses EventMachine, so the logic is wrapped in `EM.run`.
 
 ```ruby
-require 'eventmachine'
-require 'telegram'
+# When using Bundler, let it load all libraries
+require 'bundler' 
+Bundler.require(:default) 
 
-EM.run
+# Otherwise, require 'telegram', which will load its dependencies
+# require 'telegram'
+
+EM.run do
   telegram = Telegram::Client.new do |cfg|
     cfg.daemon = '/path/to/tg/bin/telegram-cli'
     cfg.key = '/path/to/tg/tg-server.pub'
@@ -72,17 +67,17 @@ EM.run
     
     # Event listeners
     # When you've received a message:
-    telegram.on[Telegram::EventType::RECEIVE_MESSAGE] = Proc.new { |event|
+    telegram.on[Telegram::EventType::RECEIVE_MESSAGE] = Proc.new do |event|
       # `tgmessage` is TelegramMessage instance
       puts event.tgmessage
-    }
+    end 
+
     # When you've sent a message:
-    telegram.on[Telegram::EventType::SEND_MESSAGE]= Proc.new { |event|
+    telegram.on[Telegram::EventType::SEND_MESSAGE] = Proc.new do |event|
       puts event
-    }
+    end
   end
 end
-
 ```
 
 ### Documentation

--- a/telegram-rb.gemspec
+++ b/telegram-rb.gemspec
@@ -14,4 +14,15 @@ Gem::Specification.new do |s|
   s.email       = 'ssut@ssut.me'
   s.files       = `git ls-files`.split("\n")
   s.homepage    = 'https://github.com/ssut/telegram-rb'
+
+  s.add_dependency('eventmachine')
+  s.add_dependency('em-synchrony')
+  s.add_dependency('em-http-request')
+  s.add_dependency('activesupport')
+  s.add_dependency('fastimage')
+  s.add_dependency('oj')
+
+  s.add_development_dependency('rubysl-irb')
+  s.add_development_dependency('yard')
+  s.add_development_dependency('ruby-prof')
 end


### PR DESCRIPTION
The library will not work without its dependencies (sadly, even ActiveSupport), so there is no point in making them optional, and force the users to discover and add each dependency manually. Gemspec solves this.
