### PR TITLE
Support optional profile config for telegram-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ EM.run
   telegram = Telegram::Client.new do |cfg|
     cfg.daemon = '/path/to/tg/bin/telegram-cli'
     cfg.key = '/path/to/tg/tg-server.pub'
+    cfg.profile = 'user2' # optional, the profiles must be configured in ~/.telegram-cli/config
   end
 
   telegram.connect do

--- a/lib/telegram/cli_arguments.rb
+++ b/lib/telegram/cli_arguments.rb
@@ -1,0 +1,50 @@
+module Telegram
+  # Command line arguments for telegram-cli
+  class CLIArguments
+    def initialize(config)
+      @config = config
+    end
+
+    def to_s
+      [
+        disable_colors,
+        rsa_key,
+        disable_names,
+        wait_dialog_list,
+        udp_socket,
+        json,
+        profile
+      ].compact.join(' ')
+    end
+
+    private
+
+    def disable_colors
+      '-C'
+    end
+
+    def rsa_key
+      "-k '#{@config.key}'"
+    end
+
+    def disable_names
+      '-I'
+    end
+
+    def wait_dialog_list
+      '-W'
+    end
+
+    def udp_socket
+      "-S '#{@config.sock}'"
+    end
+
+    def json
+      '--json'
+    end
+
+    def profile
+      "-p #{@config.profile}" if @config.profile
+    end
+  end
+end

--- a/lib/telegram/config.rb
+++ b/lib/telegram/config.rb
@@ -1,0 +1,29 @@
+require 'ostruct'
+
+module Telegram
+  # Telegram client config
+  #
+  # Available options:
+  #
+  #   * daemon: path to telegram-cli binary
+  #   * key: path to telegram-cli public key
+  #   * sock: path to Unix domain socket that telegram-cli will listen to
+  #   * size: connection pool size
+  class Config
+    extend Forwardable
+
+    DEFAULT_OPTIONS = {
+      daemon: 'bin/telegram',
+      key: 'tg-server.pub',
+      sock: 'tg.sock',
+      size: 5
+    }.freeze
+
+    def_delegators :@options, :daemon, :daemon=, :key, :key=, :sock, :sock=,
+                   :size, :size=, :profile, :profile=
+
+    def initialize(options = {})
+      @options = OpenStruct.new(DEFAULT_OPTIONS.merge(options))
+    end
+  end
+end


### PR DESCRIPTION
`telegram-cli` allows to keep many profiles in one config file. This branch adds support for this command line argument. Also it separates the config and command line arguments into domain classes.
