### PR TITLE
Disable readline in telegram-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Ruby wrapper that communicates with the [Telegram-CLI](https://github.com/vysh
 
 ### Requirements
 
-* You need to install the [Telegram-CLI](https://github.com/vysheng/tg) first.
+* You need to install the [Telegram-CLI](https://github.com/vysheng/tg) version 1.3.0 or higher first.
 
 ### RubyGems
 

--- a/lib/telegram/cli_arguments.rb
+++ b/lib/telegram/cli_arguments.rb
@@ -13,6 +13,7 @@ module Telegram
         wait_dialog_list,
         udp_socket,
         json,
+        disable_readline,
         profile
       ].compact.join(' ')
     end
@@ -41,6 +42,10 @@ module Telegram
 
     def json
       '--json'
+    end
+
+    def disable_readline
+      '-R'
     end
 
     def profile

--- a/lib/telegram/client.rb
+++ b/lib/telegram/client.rb
@@ -95,28 +95,14 @@ module Telegram
     #
     # @api private
     def poll
-      data = ''
       logger.info("Start polling for events")
-      loop do
+      while (data = @stdout.readline)
         begin
-          byte = @stdout.read_nonblock 1
-        rescue IO::WaitReadable
-          IO.select([@stdout])
-          retry
-        rescue EOFError
-          logger.error("EOFError occurred during the polling")
-          return
-        end
-        data << byte unless @starts_at.nil?
-        if byte.include?("\n")
-          begin
-            brace = data.index('{')
-            data = data[brace..-2]
-            data = Oj.load(data, mode: :compat)
-            @events << data
-          rescue
-          end
-          data = ''
+          brace = data.index('{')
+          data = data[brace..-2]
+          data = Oj.load(data, mode: :compat)
+          @events << data
+        rescue
         end
       end
     end


### PR DESCRIPTION
Readline UI is difficult to automate. telegram-cli since version 1.3.0 allows disabling readline.

Without it, the poll cycle can be simplified drastically.

Also, it fixes a possible memory leak. When nothing happens, the `data` string is appended with `\r\e[K>` every sporadic amount of seconds, as readline redraws the prompt. Theoretically, the `data` can grow to unlimited size this way.

Also for some reason I could not get two clients to work simultaneously in separate threads. But with this change, they work okay.

@ssut please help test if this change does not break anything. I tested message sending and receiving.
