### PR TITLE
Ditch ActiveSupport

### DIFF
--- a/lib/telegram/client.rb
+++ b/lib/telegram/client.rb
@@ -1,17 +1,12 @@
 # encoding: utf-8
 require 'eventmachine'
-require "em-synchrony"
+require 'em-synchrony'
 require 'em-synchrony/fiber_iterator'
 require 'em-http-request'
-require 'ostruct'
 require 'oj'
-require 'shellwords'
 require 'date'
 require 'tempfile'
 require 'fastimage'
-require 'active_support/core_ext/object/try'
-
-require 'ext/string'
 
 require 'telegram/config'
 require 'telegram/cli_arguments'

--- a/lib/telegram/events.rb
+++ b/lib/telegram/events.rb
@@ -123,7 +123,7 @@ module Telegram
     # @since [0.1.0]
     def initialize(client, event = EventType::UNKNOWN_EVENT, action = ActionType::NO_ACTION, data = {})
       @client = client
-      @id = data.try(:[], 'id') || ''
+      @id = data.respond_to?(:[]) ? data['id'] : ''
       @message = nil
       @tgmessage = nil
       @raw_data = data
@@ -163,7 +163,8 @@ module Telegram
 
       message.id = @id
       message.text = @raw_data['text'] ||= ''
-      message.type = @raw_data['media'].try(:[], 'type') || 'text'
+      media = @raw_data['media']
+      message.type = media ? media['type'] : 'text'
       message.raw_from = @raw_data['from']['peer_id']
       message.from_type = @raw_data['from']['peer_type']
       message.raw_to = @raw_data['to']['peer_id']
@@ -194,7 +195,7 @@ module Telegram
           if type == 'encr_chat' then
             @message.to = chat
           else
-            @message.from = chat 
+            @message.from = chat
           end
         when 'user'
           user = TelegramContact.pick_or_new(@client, @raw_data['to'])

--- a/telegram-rb.gemspec
+++ b/telegram-rb.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency('eventmachine')
   s.add_dependency('em-synchrony')
   s.add_dependency('em-http-request')
-  s.add_dependency('activesupport')
   s.add_dependency('fastimage')
   s.add_dependency('oj')
 


### PR DESCRIPTION
ActiveSupport comes with a bunch of dependencies of its own like `minitest`, `concurrent-ruby`, `i18n`. And the less dependencies you have to manage, the better. Especially when ActiveSupport seems to be used only for its `.try` method in two places. This can be easily avoided.
