### PR TITLE
Allow configure logger for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ EM.run do
     cfg.daemon = '/path/to/tg/bin/telegram-cli'
     cfg.key = '/path/to/tg/tg-server.pub'
     cfg.profile = 'user2' # optional, the profiles must be configured in ~/.telegram-cli/config
+    cfg.logger = Logger.new(STDOUT) # optional, default logger will be created if not set
   end
 
   telegram.connect do

--- a/lib/telegram/client.rb
+++ b/lib/telegram/client.rb
@@ -62,6 +62,7 @@ module Telegram
     def initialize(&block)
       @config = Telegram::Config.new
       yield @config
+      @logger = @config.logger if @config.logger
       @connected = 0
       @stdout = nil
       @connect_callback = nil

--- a/lib/telegram/config.rb
+++ b/lib/telegram/config.rb
@@ -20,7 +20,7 @@ module Telegram
     }.freeze
 
     def_delegators :@options, :daemon, :daemon=, :key, :key=, :sock, :sock=,
-                   :size, :size=, :profile, :profile=
+                   :size, :size=, :profile, :profile=, :logger, :logger=
 
     def initialize(options = {})
       @options = OpenStruct.new(DEFAULT_OPTIONS.merge(options))


### PR DESCRIPTION
This branch adds optional config key `logger`, which allows users to set custom per-client logger.
