### PR TITLE
Add optional config_file setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ EM.run do
   telegram = Telegram::Client.new do |cfg|
     cfg.daemon = '/path/to/tg/bin/telegram-cli'
     cfg.key = '/path/to/tg/tg-server.pub'
+    cfg.config_file = '/path/to/config' # optional, default file will be used if not set
     cfg.profile = 'user2' # optional, the profiles must be configured in ~/.telegram-cli/config
     cfg.logger = Logger.new(STDOUT) # optional, default logger will be created if not set
   end

--- a/lib/telegram/cli_arguments.rb
+++ b/lib/telegram/cli_arguments.rb
@@ -14,7 +14,8 @@ module Telegram
         udp_socket,
         json,
         disable_readline,
-        profile
+        profile,
+        config_file
       ].compact.join(' ')
     end
 
@@ -50,6 +51,10 @@ module Telegram
 
     def profile
       "-p #{@config.profile}" if @config.profile
+    end
+
+    def config_file
+      "-c #{@config.config_file}" if @config.config_file
     end
   end
 end

--- a/lib/telegram/client.rb
+++ b/lib/telegram/client.rb
@@ -80,11 +80,7 @@ module Telegram
       cli_arguments = Telegram::CLIArguments.new(@config)
       command = "'#{@config.daemon}' #{cli_arguments.to_s}"
       @stdout = IO.popen(command)
-      loop do
-        if t = @stdout.readline then
-          break if t.include?('I: config')
-        end
-      end
+      @stdout.readline
       proc {}
     end
 

--- a/lib/telegram/config.rb
+++ b/lib/telegram/config.rb
@@ -20,7 +20,8 @@ module Telegram
     }.freeze
 
     def_delegators :@options, :daemon, :daemon=, :key, :key=, :sock, :sock=,
-                   :size, :size=, :profile, :profile=, :logger, :logger=
+                   :size, :size=, :profile, :profile=, :logger, :logger=,
+                   :config_file, :config_file=
 
     def initialize(options = {})
       @options = OpenStruct.new(DEFAULT_OPTIONS.merge(options))


### PR DESCRIPTION
This branch adds optional config_file setting that corresponds to `telegram-cli`'s `--config-file/-c` and allows to load configuration from non-default file.
