### PR TITLE
Fix .escape! bug

### DIFF
--- a/lib/telegram/client.rb
+++ b/lib/telegram/client.rb
@@ -17,6 +17,7 @@ require 'telegram/callback'
 require 'telegram/api'
 require 'telegram/models'
 require 'telegram/events'
+require 'ext/string'
 
 module Telegram
   # Telegram Client


### PR DESCRIPTION
I accidentally deleted the `require 'ext/string'` line in #17. This breaks `.msg`, `.create_group_chat` and `.add_contact`.

Terribly sorry for that. This branch fixes this.
