### PR TITLE
Removed escaping for messages

### DIFF
--- a/lib/telegram/api.rb
+++ b/lib/telegram/api.rb
@@ -124,7 +124,7 @@ module Telegram
     #   end
     def msg(target, text, &callback)
       assert!
-      @connection.communicate(['msg', target, text.escape], &callback)
+      @connection.communicate(['msg', target, text], &callback)
     end
 
     # Mark as read all received messages with specific user


### PR DESCRIPTION
`String.escape` modify original message, as result message `Letter "A"` will be sent as `Letter \"A\"`, which is unexpected and incorrect, currently `telegram-cli msg` command handle all escaped chars well and there is no need manually modify message
